### PR TITLE
Test provider on earlier versions of KeyCloak too

### DIFF
--- a/.github/workflows/build-test-image.yml
+++ b/.github/workflows/build-test-image.yml
@@ -18,6 +18,11 @@ jobs:
       matrix:
         keycloak-version:
           - '23.0.3'
+          - '22.0.5'
+          - '21.0.1'
+          - '20.0.5'
+          - '19.0.2'
+
       fail-fast: false
     concurrency:
       group: docker-build-${{ matrix.keycloak-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,10 @@ jobs:
       matrix:
         keycloak-version:
           - '23.0.3'
+          - '22.0.5'
+          - '21.0.1'
+          - '20.0.5'
+          - '19.0.2'
       fail-fast: false
     concurrency:
       group: ${{ github.head_ref || github.run_id }}-${{ matrix.keycloak-version }}


### PR DESCRIPTION
- Change tested versions. Adjust testing workflows to qed's account
- Add packages: read permission to test.yml acceptance job
- Test provider on earlier versions of KeyCloak too
