### PR TITLE
Add sleep before check TestAccKeycloakDataSourceRealm_basic

### DIFF
--- a/provider/data_source_keycloak_realm_test.go
+++ b/provider/data_source_keycloak_realm_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+	"time"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -16,7 +17,10 @@ func TestAccKeycloakDataSourceRealm_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testAccProviderFactories,
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          func() {
+			testAccPreCheck(t)
+			time.Sleep(10 * time.Second)
+		},
 		CheckDestroy:      testAccCheckKeycloakRealmDestroy(),
 		Steps: []resource.TestStep{
 			{


### PR DESCRIPTION
- Change tested versions. Adjust testing workflows to qed's account
- Add packages: read permission to test.yml acceptance job
- Test provider on earlier versions of KeyCloak too
- Add sleep before check TestAccKeycloakDataSourceRealm_basic
