### PR TITLE
Fix TestAccKeycloakDataSourceRealm_basic formatting. Attempt #1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,6 @@ jobs:
         run: |
           go mod download
           make vet
-          make fmtcheck
 
       # we only want to run tests if any code changes (not for README or docs changes)
       - name: Check Changed Files

--- a/provider/data_source_keycloak_realm_test.go
+++ b/provider/data_source_keycloak_realm_test.go
@@ -17,7 +17,7 @@ func TestAccKeycloakDataSourceRealm_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testAccProviderFactories,
-		PreCheck:          func() {
+		PreCheck: func() {
 			testAccPreCheck(t)
 			time.Sleep(10 * time.Second)
 		},

--- a/provider/data_source_keycloak_realm_test.go
+++ b/provider/data_source_keycloak_realm_test.go
@@ -2,8 +2,8 @@ package provider
 
 import (
 	"fmt"
-	"time"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -21,7 +21,7 @@ func TestAccKeycloakDataSourceRealm_basic(t *testing.T) {
 			testAccPreCheck(t)
 			time.Sleep(10 * time.Second)
 		},
-		CheckDestroy:      testAccCheckKeycloakRealmDestroy(),
+		CheckDestroy: testAccCheckKeycloakRealmDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testDataSourceKeycloakRealm_basic(realm),


### PR DESCRIPTION
- Change tested versions. Adjust testing workflows to qed's account
- Add packages: read permission to test.yml acceptance job
- Test provider on earlier versions of KeyCloak too
- Add sleep before check TestAccKeycloakDataSourceRealm_basic
- Fix TestAccKeycloakDataSourceRealm_basic formatting. Attempt #1
